### PR TITLE
Fixes for CMD check

### DIFF
--- a/src/cran.h
+++ b/src/cran.h
@@ -1,0 +1,5 @@
+/* Mask printf for CMD check */
+#include <Rinternals.h>
+#define printf Rprintf
+#define fprintf(err, ...) Rprintf(__VA_ARGS__)
+#define exit assert

--- a/src/unix/config.h
+++ b/src/unix/config.h
@@ -1,3 +1,6 @@
+/* Mask illegal functions for CMD check */
+#include "cran.h"
+
 /* config.h.  Generated from config.h.in by configure.  */
 /* config.h.in.  Generated from configure.in by autoheader.  */
 

--- a/src/windows/config.h
+++ b/src/windows/config.h
@@ -1,3 +1,6 @@
+/* Mask illegal functions for CMD check */
+#include "cran.h"
+
 /* config.h.  Generated from config.h.in by configure.  */
 /* config.h.in.  Generated from configure.in by autoheader.  */
 


### PR DESCRIPTION
I think this is the most elegant (least ugly) way of fixing this. We don't change the actual upstream code but instead mask the illegal functions with the corresponding legal alternatives.