### PR TITLE
WIP: Equality of autogenerated colnames (xls vs. xlsx)

### DIFF
--- a/tests/testthat/test-colnames.R
+++ b/tests/testthat/test-colnames.R
@@ -1,6 +1,6 @@
 context("Colnames")
 
-test_that("dates respsect worksheet date sheeting", {
+test_that("auto-generated column names are the same for xls and xlsx files", {
   xls <- read_xls("missing-values.xls", col_names = FALSE)
   xlsx <- read_xlsx("missing-values.xlsx", col_names = FALSE)
 

--- a/tests/testthat/test-colnames.R
+++ b/tests/testthat/test-colnames.R
@@ -1,0 +1,8 @@
+context("Colnames")
+
+test_that("dates respsect worksheet date sheeting", {
+  xls <- read_xls("missing-values.xls", col_names = FALSE)
+  xlsx <- read_xlsx("missing-values.xlsx", col_names = FALSE)
+
+  expect_equal(colnames(xls), colnames(xlsx))
+})


### PR DESCRIPTION
With `col_names = FALSE`, .xls colnames start with X0 and .xlsx colnames start with X1. Shall column names always begin with X1?

So far, this pull request only contains a failing test.

Test output:

```
1. Failure (at test-colnames.R#7): auto-generated column names are the same for xls and xlsx files 
colnames(xls) not equal to colnames(xlsx)
2 string mismatches:
x[1]: "X0"
y[1]: "X1"

x[2]: "X1"
y[2]: "X2"
```

(Funny: Another real-life Excel file shows the same behavior **the other way round**: [xls](https://dl.dropboxusercontent.com/u/5686591/be-b-00.04-rgs-14.xls) [xlsx](https://dl.dropboxusercontent.com/u/5686591/be-b-00.04-rgs-14.xlx))
