### PR TITLE
read_excel now accepts a vector of NA types

### DIFF
--- a/R/read_excel.R
+++ b/R/read_excel.R
@@ -12,8 +12,8 @@ NULL
 #'   or a character vector giving a name for each column.
 #' @param col_types Either \code{NULL} to guess from the spreadsheet or a
 #'   character vector containing "blank", "numeric", "date" or "text".
-#' @param na Missing value. By default readxl converts blank cells to missing
-#'   data. Set this value if you have used a sentinel value for missing values.
+#' @param na Missing values. By default readxl converts blank cells to missing
+#'   data. Set this value if you have used sentinel values for missing values.
 #' @param skip Number of rows to skip before reading any data.
 #' @export
 #' @examples

--- a/src/CellType.h
+++ b/src/CellType.h
@@ -48,13 +48,13 @@ inline std::string cellTypeDesc(CellType type) {
 
 inline CellType cellType(xls::st_cell::st_cell_data cell, xls::st_xf* styles,
                          const std::set<int>& customDateFormats,
-                         std::string na = "") {
+                         std::vector<std::string> na = {""}) {
   // Find codes in [MS-XLS] S2.3.2 (p175).
   // See xls_addCell for those used for cells
   switch(cell.id) {
   case 253: // LabelSst
   case 516: // Label
-    return (na.compare((char*) cell.str) == 0) ? CELL_BLANK : CELL_TEXT;
+    return (std::any_of(na.cbegin(), na.cend(), [&](std::string i){ return i.compare((char*) cell.str) == 0; })) ? CELL_BLANK : CELL_TEXT;
     break;
 
   case 6:    // formula
@@ -62,7 +62,7 @@ inline CellType cellType(xls::st_cell::st_cell_data cell, xls::st_xf* styles,
     if (cell.l == 0) {
       return CELL_NUMERIC;
     } else {
-      if (na.compare((char*) cell.str) == 0) {
+      if (std::any_of(na.cbegin(), na.cend(), [&](std::string i){ return i.compare((char*) cell.str) == 0; })) {
         return CELL_BLANK;
       } else {
         return CELL_TEXT;

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -41,13 +41,13 @@ BEGIN_RCPP
 END_RCPP
 }
 // xls_col_types
-CharacterVector xls_col_types(std::string path, std::string na, int sheet, int nskip, int n, bool has_col_names);
+CharacterVector xls_col_types(std::string path, std::vector<std::string> na, int sheet, int nskip, int n, bool has_col_names);
 RcppExport SEXP readxl_xls_col_types(SEXP pathSEXP, SEXP naSEXP, SEXP sheetSEXP, SEXP nskipSEXP, SEXP nSEXP, SEXP has_col_namesSEXP) {
 BEGIN_RCPP
     Rcpp::RObject __result;
     Rcpp::RNGScope __rngScope;
     Rcpp::traits::input_parameter< std::string >::type path(pathSEXP);
-    Rcpp::traits::input_parameter< std::string >::type na(naSEXP);
+    Rcpp::traits::input_parameter< std::vector<std::string> >::type na(naSEXP);
     Rcpp::traits::input_parameter< int >::type sheet(sheetSEXP);
     Rcpp::traits::input_parameter< int >::type nskip(nskipSEXP);
     Rcpp::traits::input_parameter< int >::type n(nSEXP);
@@ -57,7 +57,7 @@ BEGIN_RCPP
 END_RCPP
 }
 // xls_cols
-List xls_cols(std::string path, int i, CharacterVector col_names, CharacterVector col_types, std::string na, int nskip);
+List xls_cols(std::string path, int i, CharacterVector col_names, CharacterVector col_types, std::vector<std::string> na, int nskip);
 RcppExport SEXP readxl_xls_cols(SEXP pathSEXP, SEXP iSEXP, SEXP col_namesSEXP, SEXP col_typesSEXP, SEXP naSEXP, SEXP nskipSEXP) {
 BEGIN_RCPP
     Rcpp::RObject __result;
@@ -66,7 +66,7 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< int >::type i(iSEXP);
     Rcpp::traits::input_parameter< CharacterVector >::type col_names(col_namesSEXP);
     Rcpp::traits::input_parameter< CharacterVector >::type col_types(col_typesSEXP);
-    Rcpp::traits::input_parameter< std::string >::type na(naSEXP);
+    Rcpp::traits::input_parameter< std::vector<std::string> >::type na(naSEXP);
     Rcpp::traits::input_parameter< int >::type nskip(nskipSEXP);
     __result = Rcpp::wrap(xls_cols(path, i, col_names, col_types, na, nskip));
     return __result;
@@ -140,14 +140,14 @@ BEGIN_RCPP
 END_RCPP
 }
 // xlsx_col_types
-CharacterVector xlsx_col_types(std::string path, int sheet, std::string na, int nskip, int n);
+CharacterVector xlsx_col_types(std::string path, int sheet, std::vector<std::string> na, int nskip, int n);
 RcppExport SEXP readxl_xlsx_col_types(SEXP pathSEXP, SEXP sheetSEXP, SEXP naSEXP, SEXP nskipSEXP, SEXP nSEXP) {
 BEGIN_RCPP
     Rcpp::RObject __result;
     Rcpp::RNGScope __rngScope;
     Rcpp::traits::input_parameter< std::string >::type path(pathSEXP);
     Rcpp::traits::input_parameter< int >::type sheet(sheetSEXP);
-    Rcpp::traits::input_parameter< std::string >::type na(naSEXP);
+    Rcpp::traits::input_parameter< std::vector<std::string> >::type na(naSEXP);
     Rcpp::traits::input_parameter< int >::type nskip(nskipSEXP);
     Rcpp::traits::input_parameter< int >::type n(nSEXP);
     __result = Rcpp::wrap(xlsx_col_types(path, sheet, na, nskip, n));
@@ -168,7 +168,7 @@ BEGIN_RCPP
 END_RCPP
 }
 // read_xlsx_
-List read_xlsx_(std::string path, int sheet, RObject col_names, RObject col_types, std::string na, int nskip);
+List read_xlsx_(std::string path, int sheet, RObject col_names, RObject col_types, std::vector<std::string> na, int nskip);
 RcppExport SEXP readxl_read_xlsx_(SEXP pathSEXP, SEXP sheetSEXP, SEXP col_namesSEXP, SEXP col_typesSEXP, SEXP naSEXP, SEXP nskipSEXP) {
 BEGIN_RCPP
     Rcpp::RObject __result;
@@ -177,7 +177,7 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< int >::type sheet(sheetSEXP);
     Rcpp::traits::input_parameter< RObject >::type col_names(col_namesSEXP);
     Rcpp::traits::input_parameter< RObject >::type col_types(col_typesSEXP);
-    Rcpp::traits::input_parameter< std::string >::type na(naSEXP);
+    Rcpp::traits::input_parameter< std::vector<std::string> >::type na(naSEXP);
     Rcpp::traits::input_parameter< int >::type nskip(nskipSEXP);
     __result = Rcpp::wrap(read_xlsx_(path, sheet, col_names, col_types, na, nskip));
     return __result;

--- a/src/XlsWorkSheet.cpp
+++ b/src/XlsWorkSheet.cpp
@@ -13,7 +13,7 @@ CharacterVector xls_col_names(std::string path, int i = 0, int nskip = 0) {
 }
 
 // [[Rcpp::export]]
-CharacterVector xls_col_types(std::string path, std::string na, int sheet = 0,
+CharacterVector xls_col_types(std::string path, std::vector<std::string> na, int sheet = 0,
                               int nskip = 0, int n = 100, bool has_col_names = false) {
   XlsWorkBook wb = XlsWorkBook(path);
   std::vector<CellType> types = wb.sheet(sheet).colTypes(na, nskip + has_col_names, n);
@@ -37,7 +37,7 @@ CharacterVector xls_col_types(std::string path, std::string na, int sheet = 0,
 
 // [[Rcpp::export]]
 List xls_cols(std::string path, int i, CharacterVector col_names,
-              CharacterVector col_types, std::string na, int nskip = 0) {
+              CharacterVector col_types, std::vector<std::string> na, int nskip = 0) {
   XlsWorkBook wb = XlsWorkBook(path);
   XlsWorkSheet sheet = wb.sheet(i);
 

--- a/src/XlsWorkSheet.h
+++ b/src/XlsWorkSheet.h
@@ -65,7 +65,7 @@ public:
     return out;
   }
 
-  std::vector<CellType> colTypes(std::string na, int nskip = 0, int n_max = 100) {
+  std::vector<CellType> colTypes(std::vector<std::string> na, int nskip = 0, int n_max = 100) {
     std::vector<CellType> types(ncol_);
 
     for (int i = nskip; i < nrow_ && i < n_max; ++i) {
@@ -88,7 +88,7 @@ public:
   }
 
   Rcpp::List readCols(Rcpp::CharacterVector names, std::vector<CellType> types,
-                      std::string na, int nskip = 0) {
+                      std::vector<std::string> na, int nskip = 0) {
     if ((int) names.size() != ncol_ || (int) types.size() != ncol_)
       Rcpp::stop("Need one name and type for each column");
 
@@ -154,7 +154,7 @@ public:
             SET_STRING_ELT(col, i, NA_STRING);
           } else {
             std::string stdString((char*) cell.str);
-            Rcpp::RObject rString = stdString == na ? NA_STRING : Rf_mkCharCE(stdString.c_str(), CE_UTF8);
+            Rcpp::RObject rString = std::any_of(na.cbegin(), na.cend(), [&stdString](std::string i){ return i == stdString; }) ? NA_STRING : Rf_mkCharCE(stdString.c_str(), CE_UTF8);
             SET_STRING_ELT(col, i, rString);
           }
           break;

--- a/src/XlsxCell.h
+++ b/src/XlsxCell.h
@@ -65,31 +65,31 @@ public:
     return stringTable.at(id);
   }
 
-  double asDouble(const std::string& na) {
+  double asDouble(const std::vector<std::string>& na) {
     rapidxml::xml_node<>* v = cell_->first_node("v");
-    if (v == NULL || na.compare(v->value()) == 0)
+    if (v == NULL || std::any_of(na.cbegin(), na.cend(), [&v](std::string i){ return i.compare(v->value()) == 0; }))
       return NA_REAL;
 
     return (v == NULL) ? 0 : atof(v->value());
   }
 
-  double asDate(const std::string& na, int offset) {
+  double asDate(const std::vector<std::string>& na, int offset) {
     rapidxml::xml_node<>* v = cell_->first_node("v");
-    if (v == NULL || na.compare(v->value()) == 0)
+    if (v == NULL || std::any_of(na.cbegin(), na.cend(), [&v](std::string i){ return i.compare(v->value()) == 0; }))
       return NA_REAL;
 
     double value = atof(v->value());
     return (v == NULL) ? 0 : (value - offset) * 86400;
   }
 
-  Rcpp::RObject asCharSxp(const std::string& na,
+  Rcpp::RObject asCharSxp(const std::vector<std::string>& na,
                           const std::vector<std::string>& stringTable) {
 
     // Is it an inline string?  // 18.3.1.53 is (Rich Text Inline) [p1649]
     rapidxml::xml_node<>* is = cell_->first_node("is");
     if (is != NULL) {
       std::string value;
-      if (!parseString(is, &value) || na.compare(value) == 0) {
+      if (!parseString(is, &value) || std::any_of(na.cbegin(), na.cend(), [&value](std::string i){ return i.compare(value) == 0; })) {
         return NA_STRING;
       } else {
         return Rf_mkCharCE(value.c_str(), CE_UTF8);
@@ -106,7 +106,7 @@ public:
     if (t != NULL && strncmp(t->value(), "s", t->value_size()) == 0) {
       return stringFromTable(v->value(), na, stringTable);
     } else {
-      if (na.compare(v->value()) == 0) {
+      if (std::any_of(na.cbegin(), na.cend(), [&v](std::string i){ return i.compare(v->value()) == 0; })) {
         return NA_STRING;
       } else {
         return Rf_mkCharCE(v->value(), CE_UTF8);
@@ -114,7 +114,7 @@ public:
     }
   }
 
-  CellType type(const std::string& na,
+  CellType type(const std::vector<std::string>& na,
                 const std::vector<std::string>& stringTable,
                 const std::set<int>& dateStyles) {
     rapidxml::xml_attribute<>* t = cell_->first_attribute("t");
@@ -140,13 +140,13 @@ public:
 
       int id = atoi(v->value());
       const std::string& string = stringTable.at(id);
-      return (string == na) ? CELL_BLANK : CELL_TEXT;
+      return (std::any_of(na.cbegin(), na.cend(), [&string](std::string i){ return i == string; })) ? CELL_BLANK : CELL_TEXT;
     } else if (strncmp(t->value(), "str", 5) == 0) { // formula
       rapidxml::xml_node<>* v = cell_->first_node("v");
       if (v == NULL)
         return CELL_BLANK;
 
-      return (na.compare(v->value()) == 0) ? CELL_BLANK : CELL_TEXT;
+      return (std::any_of(na.cbegin(), na.cend(), [&v](std::string i){ return i.compare(v->value()) == 0; })) ? CELL_BLANK : CELL_TEXT;
     } else if  (strncmp(t->value(), "inlineStr", 9) == 0) { // formula
       return CELL_TEXT;
     } else {
@@ -161,7 +161,7 @@ public:
 private:
 
 
-  Rcpp::RObject stringFromTable(const char* val, const std::string& na,
+  Rcpp::RObject stringFromTable(const char* val, const std::vector<std::string>& na,
                                 const std::vector<std::string>& stringTable) {
     int id = atoi(val);
     if (id < 0 || id >= (int) stringTable.size()) {
@@ -170,7 +170,7 @@ private:
     }
 
     const std::string& string = stringTable.at(id);
-    return (string == na) ? NA_STRING : Rf_mkCharCE(string.c_str(), CE_UTF8);
+    return (std::any_of(na.cbegin(), na.cend(), [&string](std::string i){ return i == string; })) ? NA_STRING : Rf_mkCharCE(string.c_str(), CE_UTF8);
   }
 
 };

--- a/src/XlsxWorkSheet.cpp
+++ b/src/XlsxWorkSheet.cpp
@@ -22,7 +22,7 @@ IntegerVector parse_ref(std::string ref) {
 
 // [[Rcpp::export]]
 CharacterVector xlsx_col_types(std::string path, int sheet = 0,
-                               std::string na = "", int nskip = 0,
+                               std::vector<std::string> na = {""}, int nskip = 0,
                                int n = 100) {
 
   XlsxWorkSheet ws(path, sheet);
@@ -43,7 +43,7 @@ CharacterVector xlsx_col_names(std::string path, int sheet = 0, int nskip = 0) {
 
 // [[Rcpp::export]]
 List read_xlsx_(std::string path, int sheet, RObject col_names,
-                RObject col_types, std::string na, int nskip = 0) {
+                RObject col_types, std::vector<std::string> na, int nskip = 0) {
 
   XlsxWorkSheet ws(path, sheet);
 

--- a/src/XlsxWorkSheet.h
+++ b/src/XlsxWorkSheet.h
@@ -57,13 +57,13 @@ public:
 
         XlsxCell xcell(cell);
         Rcpp::Rcout << xcell.row() << "," << xcell.row() << ": " <<
-          cellTypeDesc(xcell.type("", wb_.stringTable(), wb_.dateStyles())) << "\n";
+          cellTypeDesc(xcell.type({""}, wb_.stringTable(), wb_.dateStyles())) << "\n";
       }
     }
   }
 
 
-  std::vector<CellType> colTypes(const std::string& na, int nskip = 0, int n_max = 100, bool has_col_names = false) {
+  std::vector<CellType> colTypes(const std::vector<std::string>& na, int nskip = 0, int n_max = 100, bool has_col_names = false) {
     rapidxml::xml_node<>* row = getRow(nskip + has_col_names);
     std::vector<CellType> types;
     types.resize(ncol_);
@@ -109,7 +109,7 @@ public:
 
       if (xcell.col() >= ncol_)
         continue;
-      out[xcell.col()] = xcell.asCharSxp("", wb_.stringTable());
+      out[xcell.col()] = xcell.asCharSxp({""}, wb_.stringTable());
     }
 
     return out;
@@ -117,7 +117,7 @@ public:
 
   Rcpp::List readCols(Rcpp::CharacterVector names,
                       const std::vector<CellType>& types,
-                      const std::string& na, int nskip = 0) {
+                      const std::vector<std::string>& na, int nskip = 0) {
     if ((int) names.size() != ncol_ || (int) types.size() != ncol_)
       Rcpp::stop("Need one name and type for each column");
 


### PR DESCRIPTION
Can be tested on this test Excel file:

https://drive.google.com/file/d/0B1i6iIc4UbO1VUV6TWQ0RjlFT1U/view?usp=sharing

Using this code:

```
read_excel("test_mult_na.xlsx",sheet=1,col_names=T,
           col_types=c("text","numeric","numeric"),na=c("","-","NA"))
```

I get this output, as expected:

```
  var1     var2 var3
1    a    1.300    1
2    b       NA    2
3    c   51.500    3
4 <NA>    9.900    4
5    e 8548.400    5
6    f  848.560    6
7    g   32.498   NA
```
