### PR TITLE
Updating readxl to read 1000 rows before guessing col_type like readr

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,3 +2,5 @@
 
 * Add support for correctly reading strings in .xlsx files containing escaped 
   unicode characters (e.g. `_x005F_`) (#51, thanks to @jmarshallnz).
+
+* Bumped up row inspection for column typing guessing from 100 to 1000 to align with readr (#143).

--- a/src/XlsWorkSheet.cpp
+++ b/src/XlsWorkSheet.cpp
@@ -14,7 +14,7 @@ CharacterVector xls_col_names(std::string path, int i = 0, int nskip = 0) {
 
 // [[Rcpp::export]]
 CharacterVector xls_col_types(std::string path, std::string na, int sheet = 0,
-                              int nskip = 0, int n = 100, bool has_col_names = false) {
+                              int nskip = 0, int n = 1000, bool has_col_names = false) {
   XlsWorkBook wb = XlsWorkBook(path);
   std::vector<CellType> types = wb.sheet(sheet).colTypes(na, nskip + has_col_names, n);
 

--- a/src/XlsWorkSheet.h
+++ b/src/XlsWorkSheet.h
@@ -65,7 +65,7 @@ public:
     return out;
   }
 
-  std::vector<CellType> colTypes(std::string na, int nskip = 0, int n_max = 100) {
+  std::vector<CellType> colTypes(std::string na, int nskip = 0, int n_max = 1000) {
     std::vector<CellType> types(ncol_);
 
     for (int i = nskip; i < nrow_ && i < n_max; ++i) {

--- a/src/XlsxWorkSheet.cpp
+++ b/src/XlsxWorkSheet.cpp
@@ -23,7 +23,7 @@ IntegerVector parse_ref(std::string ref) {
 // [[Rcpp::export]]
 CharacterVector xlsx_col_types(std::string path, int sheet = 0,
                                std::string na = "", int nskip = 0,
-                               int n = 100) {
+                               int n = 1000) {
 
   XlsxWorkSheet ws(path, sheet);
   std::vector<CellType> types = ws.colTypes(na, nskip, n);

--- a/src/XlsxWorkSheet.cpp
+++ b/src/XlsxWorkSheet.cpp
@@ -76,7 +76,7 @@ List read_xlsx_(std::string path, int sheet, RObject col_names,
   std::vector<CellType> colTypes;
   switch(TYPEOF(col_types)) {
   case NILSXP:
-    colTypes = ws.colTypes(na, nskip, 100, sheetHasColumnNames);
+    colTypes = ws.colTypes(na, nskip, 1000, sheetHasColumnNames);
     break;
   case STRSXP:
     colTypes = cellTypes(as<CharacterVector>(col_types));

--- a/src/XlsxWorkSheet.h
+++ b/src/XlsxWorkSheet.h
@@ -63,7 +63,7 @@ public:
   }
 
 
-  std::vector<CellType> colTypes(const std::string& na, int nskip = 0, int n_max = 100, bool has_col_names = false) {
+  std::vector<CellType> colTypes(const std::string& na, int nskip = 0, int n_max = 1000, bool has_col_names = false) {
     rapidxml::xml_node<>* row = getRow(nskip + has_col_names);
     std::vector<CellType> types;
     types.resize(ncol_);


### PR DESCRIPTION
I've got some fugly spreadsheets that I work with that have a lot of missing data and now that readr reads 1000 rows, it doesn't guess wrong very often, but readxl is still only using 100 rows. I believe I've found them all and changed them from 100 to 1000. I've tested this on various xlsx and xls documents and haven't been let down yet. 
