### PR TITLE
Partially addresses #169 by warning for blank columns

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # readxl 0.1.1.9000
 
+* read_excel warns when finding blank columns in .xls files; related to [#81](https://github.com/hadley/readxl/issues/81), [#169](https://github.com/hadley/readxl/issues/169). 
+
 # readxl 0.1.1
 
 * Add support for correctly reading strings in .xlsx files containing escaped 

--- a/R/read_excel.R
+++ b/R/read_excel.R
@@ -49,6 +49,9 @@ read_xls <- function(path, sheet = 1, col_names = TRUE, col_types = NULL,
 
   if (is.null(col_types)) {
     col_types <- xls_col_types(path, sheet, na = na, nskip = skip, has_col_names = has_col_names)
+    if (any(idx <- col_types == "blank")) 
+      warning("Found blank columns: ", 
+              paste(which(idx), collapse = ","))
   }
 
   xls_cols(path, sheet, col_names = col_names, col_types = col_types, na = na,


### PR DESCRIPTION
Barring a good solution to #81 and #169, this will at least tell the user which columns are being considered as blank so they can adjust their `col_names`/`col_types` accordingly.
