### PR TITLE
Fixed invalid use of va_list

### DIFF
--- a/src/xlstool.c
+++ b/src/xlstool.c
@@ -169,13 +169,14 @@ static int asprintf(char **ret, const char *format, ...)
 	int i;
     char *str;
 
-	va_list ap;
+	va_list ap, ap2;
 
 	va_start(ap, format); 
+	va_copy(ap2, ap);
 
 	i = vsnprintf(NULL, 0, format, ap) + 1;
 	str = (char *)malloc(i);
-	i = vsnprintf(str, i, format, ap);
+	i = vsnprintf(str, i, format, ap2);
 
 	va_end(ap);
 

--- a/src/xlstool.c
+++ b/src/xlstool.c
@@ -167,17 +167,18 @@ static int asprintf(char **ret, const char *format, ...)
 static int asprintf(char **ret, const char *format, ...)
 {
 	int i;
-    char *str;
+	char *str;
 
-	va_list ap, ap2;
+	va_list ap;
 
 	va_start(ap, format); 
-	va_copy(ap2, ap);
-
 	i = vsnprintf(NULL, 0, format, ap) + 1;
-	str = (char *)malloc(i);
-	i = vsnprintf(str, i, format, ap2);
+	va_end(ap);
 
+	str = (char *)malloc(i);
+
+	va_start(ap, format);
+	i = vsnprintf(str, i, format, ap);
 	va_end(ap);
 
 	*ret = str;


### PR DESCRIPTION
It's not standards compliant to use a va_list in more than one call. Unfortunately this works on _some_ platforms.

See http://stackoverflow.com/questions/9309246/repeated-use-of-a-variadic-function-argument-doesnt-work
