### PR TITLE
More helpful error for blank issue in #81 and #169

### DIFF
--- a/src/XlsWorkSheet.h
+++ b/src/XlsWorkSheet.h
@@ -90,7 +90,7 @@ public:
   Rcpp::List readCols(Rcpp::CharacterVector names, std::vector<CellType> types,
                       std::string na, int nskip = 0) {
     if ((int) names.size() != ncol_ || (int) types.size() != ncol_)
-      Rcpp::stop("Need one name and type for each column");
+      Rcpp::stop("Need one name and type for each column (%d columns)", ncol_);
 
     Rcpp::List cols(ncol_);
 

--- a/src/XlsxWorkSheet.h
+++ b/src/XlsxWorkSheet.h
@@ -119,7 +119,7 @@ public:
                       const std::vector<CellType>& types,
                       const std::string& na, int nskip = 0) {
     if ((int) names.size() != ncol_ || (int) types.size() != ncol_)
-      Rcpp::stop("Need one name and type for each column");
+      Rcpp::stop("Need one name and type for each column (%d columns)", ncol_);
 
     // Initialise columns
     int n = nrow_ - nskip;


### PR DESCRIPTION
This pull request adjusts the error message returned when the length of col_types does not match what read_excel() expects, which often occurs when there are blank columns. While it doesn't solve #81 or #169, it does provide the user helpful diagnostics, enabling them at least to know how many columns read_excel() thinks the file has.
