### PR TITLE
Closes #134; better detection of date formats

### DIFF
--- a/src/CellType.h
+++ b/src/CellType.h
@@ -116,10 +116,15 @@ inline bool isDateFormat(std::string x) {
   for (size_t i = 0; i < x.size(); ++i) {
     switch (x[i]) {
     case 'd':
+    case 'D':
     case 'm': // 'mm' for minutes
+    case 'M': 
     case 'y':
+    case 'Y':
     case 'h': // 'hh'
+    case 'H':
     case 's': // 'ss'
+    case 'S':
       return true;
     default:
       break;


### PR DESCRIPTION
I don't think there's any issue in allowing upper-case letters in the `formatCode`, as was the case in the troublesome file mentioned in #134.
