### PR TITLE
Add "Supported By Posit" badge to website

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -8,6 +8,7 @@ template:
   bootstrap: 5
   includes:
     in_header: |
+      <script src="https://cdn.jsdelivr.net/gh/posit-dev/supported-by-posit/js/badge.min.js" data-max-height="43" data-light-bg="#666f76" data-light-fg="#f9f9f9"></script>
       <script defer data-domain="readxl.tidyverse.org,all.tidyverse.org" src="https://plausible.io/js/plausible.js"></script>
 
 home:
@@ -29,35 +30,35 @@ news:
     href: https://www.rstudio.com/blog/readxl-0-1-0/
 
 reference:
-  - title: "Read spreadsheets"
-    desc: >
-      Functions for reading tabular data out of xls and xlsx files.
-    contents:
-      - read_excel
-      - read_xls
-      - read_xlsx
-  - title: "Get spreadsheet metadata"
-    desc: >
-      Functions to learn properties of xls and xlsx files.
-    contents:
-      - excel_sheets
-      - excel_format
-  - title: "Describe a target rectangle"
-    desc: >
-      Flexible specification of cell rectangles.
-    contents:
-      - "`cell-specification`"
-      - cell_rows
-      - cell_cols
-      - anchored
-      - cell_limits
-  - title: "Example files"
-    desc: >
-      List or get the path to xls and xlsx example files in the package.
-    contents:
-      - readxl_example
-  - title: "Options"
-    desc: >
-      Options consulted by readxl.
-    contents:
-      - readxl_progress
+- title: "Read spreadsheets"
+  desc: >
+    Functions for reading tabular data out of xls and xlsx files.
+  contents:
+  - read_excel
+  - read_xls
+  - read_xlsx
+- title: "Get spreadsheet metadata"
+  desc: >
+    Functions to learn properties of xls and xlsx files.
+  contents:
+  - excel_sheets
+  - excel_format
+- title: "Describe a target rectangle"
+  desc: >
+    Flexible specification of cell rectangles.
+  contents:
+  - "`cell-specification`"
+  - cell_rows
+  - cell_cols
+  - anchored
+  - cell_limits
+- title: "Example files"
+  desc: >
+    List or get the path to xls and xlsx example files in the package.
+  contents:
+  - readxl_example
+- title: "Options"
+  desc: >
+    Options consulted by readxl.
+  contents:
+  - readxl_progress

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -9,7 +9,12 @@ template:
   includes:
     in_header: |
       <script src="https://cdn.jsdelivr.net/gh/posit-dev/supported-by-posit/js/badge.min.js" data-max-height="43" data-light-bg="#666f76" data-light-fg="#f9f9f9"></script>
-      <script defer data-domain="readxl.tidyverse.org,all.tidyverse.org" src="https://plausible.io/js/plausible.js"></script>
+      <!-- Privacy-friendly analytics by Plausible -->
+      <script async src="https://plausible.io/js/pa-RiKmOPwtLHuC63AhWHW4B.js"></script>
+      <script>
+        window.plausible=window.plausible||function(){(plausible.q=plausible.q||[]).push(arguments)},plausible.init=plausible.init||function(i){plausible.o=i||{}};
+        plausible.init()
+      </script>
 
 home:
   links:


### PR DESCRIPTION
## Overview

This PR adds the "Supported by Posit" badge to the website.

## Background

We've recently started adding a "Supported by Posit" badge across all Posit package websites to create a more cohesive brand presence. The badge appears on the far right of the top navigation bar or at the bottom of the hamburger menu. It links to Posit’s main website. @hadley is involved with this initiative.

The following websites already have the "Supported by Posit" badge: [ggplot2](https://ggplot2.tidyverse.org), [Great Tables](https://posit-dev.github.io/great-tables/articles/intro.html), [gt](https://gt.rstudio.com), [Plotnine](https://plotnine.org), [Pointblank](https://posit-dev.github.io/pointblank/), [pointblank](https://rstudio.github.io/pointblank/), and [Quarto](https://quarto.org).

See https://posit-dev.github.io/supported-by-posit/ for more information.

## Changes

- Added a line to `_pkgdown.yml` to include the JavaScript file
- Standardized indentation in `_pkgdown.yml`

## Screenshots

At 1200px browser width:

![Screenshot of readxl website at 1200px browser width](https://posit-dev.github.io/supported-by-posit/screenshots/readxl-1200.png)

At 992px browser width:

![Screenshot of readxl website at 992px browser width](https://posit-dev.github.io/supported-by-posit/screenshots/readxl-992.png)

At 991px browser width:

![Screenshot of readxl website at 991px browser width](https://posit-dev.github.io/supported-by-posit/screenshots/readxl-991.png)

