### PR TITLE
Avoid cpp11::warning / cpp11::stop variadic forwarding

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -36,3 +36,5 @@
 ^CRAN-SUBMISSION$
 ^maintenance$
 ^[.]?air[.]toml$
+^compile_commands\.json$
+^\.cache$

--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -38,3 +38,4 @@
 ^[.]?air[.]toml$
 ^compile_commands\.json$
 ^\.cache$
+^\.claude$

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ scratch.R
 src/fprintf-substitution.R
 fprintf-matches.txt
 investigations
+compile_commands.json
+.cache

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ fprintf-matches.txt
 investigations
 compile_commands.json
 .cache
+.claude/settings.local.json

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -51,3 +51,4 @@ Encoding: UTF-8
 Note: libxls v1.6.3 c199d13
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.3.2
+Config/build/compilation-database: true

--- a/src/ColSpec.h
+++ b/src/ColSpec.h
@@ -95,7 +95,8 @@ inline std::vector<ColType> colTypeStrings(cpp11::strings x) {
     } else if (type == "skip") {
       types.push_back(COL_SKIP);
     } else {
-      cpp11::stop("Unknown column type '%s' at position %i", type.c_str(), (i + 1));
+      readxl_stop("Unknown column type '" + type + "' at position " +
+                  std::to_string(i + 1));
     }
   }
 
@@ -230,8 +231,11 @@ inline cpp11::strings reconcileNames(cpp11::strings names,
     }
   }
   if (ncol_names != ncol_noskip) {
-    cpp11::stop("Sheet %d has %d columns (%d unskipped), but `col_names` has length %d.",
-               (sheet_i + 1), ncol_types, ncol_noskip, ncol_names);
+    readxl_stop("Sheet " + std::to_string(sheet_i + 1) +
+                " has " + std::to_string(ncol_types) +
+                " columns (" + std::to_string(ncol_noskip) +
+                " unskipped), but `col_names` has length " +
+                std::to_string(ncol_names) + ".");
   }
 
   cpp11::writable::strings newNames(ncol_types);

--- a/src/Read.cpp
+++ b/src/Read.cpp
@@ -42,18 +42,20 @@ cpp11::list read_this_(
     colNames = has_col_names ? ws.colNames(na, trim_ws) : cpp11::writable::strings(ws.ncol());
     break;
   default:
-    cpp11::stop("`col_names` must be a logical or character vector");
+    readxl_stop("`col_names` must be a logical or character vector");
   }
 
   // Get column types --------------------------------------------------
   if (TYPEOF(col_types) != STRSXP) {
-    cpp11::stop("`col_types` must be a character vector");
+    readxl_stop("`col_types` must be a character vector");
   }
   std::vector<ColType> colTypes = colTypeStrings(col_types);
   colTypes = recycleTypes(colTypes, ws.ncol());
   if ((int) colTypes.size() != ws.ncol()) {
-    cpp11::stop("Sheet %d has %d columns, but `col_types` has length %d.",
-                sheet_i + 1, ws.ncol(), colTypes.size());
+    readxl_stop("Sheet " + std::to_string(sheet_i + 1) + " has " +
+                std::to_string(ws.ncol()) +
+                " columns, but `col_types` has length " +
+                std::to_string(colTypes.size()) + ".");
   }
   if (requiresGuess(colTypes)) {
     colTypes = ws.colTypes(colTypes, na, trim_ws, guess_max, has_col_names);

--- a/src/SheetView.h
+++ b/src/SheetView.h
@@ -174,8 +174,7 @@ public:
       case COL_LOGICAL:
         if (type == CELL_DATE) {
           // print date string here, when/if it's possible to do so
-          cpp11::warning("Expecting logical in %s: got a date",
-                         cellPosition(i, j).c_str());
+          readxl_warning("Expecting logical in " + cellPosition(i, j) + ": got a date");
         }
 
         switch(type) {
@@ -192,8 +191,7 @@ public:
           if (logicalFromString(text_string, &text_boolean)) {
             LOGICAL(column)[row] = text_boolean;
           } else {
-            cpp11::warning("Expecting logical in %s: got '%s'",
-                           cellPosition(i, j).c_str(), text_string.c_str());
+            readxl_warning("Expecting logical in " + cellPosition(i, j) + ": got '" + text_string + "'");
             LOGICAL(column)[row] = NA_LOGICAL;
           }
         }
@@ -203,26 +201,25 @@ public:
 
       case COL_DATE:
         if (type == CELL_LOGICAL) {
-          cpp11::warning("Expecting date in %s: got boolean", cellPosition(i, j).c_str());
+          readxl_warning("Expecting date in " + cellPosition(i, j) + ": got boolean");
         }
         if (type == CELL_NUMERIC) {
-          cpp11::warning("Coercing numeric to date in %s",
-                         cellPosition(i, j).c_str());
+          readxl_warning("Coercing numeric to date in " + cellPosition(i, j));
         }
         if (type == CELL_TEXT) {
-          cpp11::warning("Expecting date in %s: got '%s'", cellPosition(i, j).c_str(),
-                         (xcell->asStdString(trimWs, wb_.stringTable())).c_str());
+          readxl_warning("Expecting date in " + cellPosition(i, j) + ": got '" +
+                         xcell->asStdString(trimWs, wb_.stringTable()) + "'");
         }
         REAL(column)[row] = xcell->asDate(wb_.is1904());
         break;
 
       case COL_NUMERIC:
         if (type == CELL_LOGICAL) {
-          cpp11::warning("Coercing boolean to numeric in %s", cellPosition(i, j).c_str());
+          readxl_warning("Coercing boolean to numeric in " + cellPosition(i, j));
         }
         if (type == CELL_DATE) {
           // print date string here, when/if possible
-          cpp11::warning("Expecting numeric in %s: got a date", cellPosition(i, j).c_str());
+          readxl_warning("Expecting numeric in " + cellPosition(i, j) + ": got a date");
         }
         switch(type) {
         case CELL_UNKNOWN:
@@ -237,12 +234,10 @@ public:
           double num_num;
           bool success = doubleFromString(num_string, num_num);
           if (success) {
-            cpp11::warning("Coercing text to numeric in %s: '%s'",
-                           cellPosition(i, j).c_str(), num_string.c_str());
+            readxl_warning("Coercing text to numeric in " + cellPosition(i, j) + ": '" + num_string + "'");
             REAL(column)[row] = num_num;
           } else {
-            cpp11::warning("Expecting numeric in %s: got '%s'",
-                           cellPosition(i, j).c_str(), num_string.c_str());
+            readxl_warning("Expecting numeric in " + cellPosition(i, j) + ": got '" + num_string + "'");
             REAL(column)[row] = NA_REAL;
           }
         }

--- a/src/XlsCell.h
+++ b/src/XlsCell.h
@@ -218,8 +218,8 @@ public:
       break;
 
     default:
-      cpp11::warning("Unrecognized cell type at %s: '%s'",
-                    cellPosition(row(), col()).c_str(), cell_->id);
+      readxl_warning("Unrecognized cell type at " + cellPosition(row(), col()) +
+                     ": '" + std::to_string(cell_->id) + "'");
     ct = CELL_UNKNOWN;
     }
 
@@ -264,8 +264,8 @@ public:
     }
 
     default:
-      cpp11::warning("Unrecognized cell type at %s: '%s'",
-                    cellPosition(row(), col()).c_str(), cell_->id);
+      readxl_warning("Unrecognized cell type at " + cellPosition(row(), col()) +
+                     ": '" + std::to_string(cell_->id) + "'");
       return "";
     }
   }
@@ -291,8 +291,8 @@ public:
       return cell_->d != 0;
 
     default:
-      cpp11::warning("Unrecognized cell type at %s: '%s'",
-                    cellPosition(row(), col()).c_str(), cell_->id);
+      readxl_warning("Unrecognized cell type at " + cellPosition(row(), col()) +
+                     ": '" + std::to_string(cell_->id) + "'");
     return NA_LOGICAL;
     }
   }
@@ -311,8 +311,8 @@ public:
       return cell_->d;
 
     default:
-      cpp11::warning("Unrecognized cell type at %s: '%s'",
-                    cellPosition(row(), col()).c_str(), cell_->id);
+      readxl_warning("Unrecognized cell type at " + cellPosition(row(), col()) +
+                     ": '" + std::to_string(cell_->id) + "'");
     return NA_REAL;
     }
   }
@@ -331,8 +331,8 @@ public:
       return POSIXctFromSerial(cell_->d, is1904);
 
     default:
-      cpp11::warning("Unrecognized cell type at %s: '%s'",
-                    cellPosition(row(), col()).c_str(), cell_->id);
+      readxl_warning("Unrecognized cell type at " + cellPosition(row(), col()) +
+                     ": '" + std::to_string(cell_->id) + "'");
     return NA_REAL;
     }
   }

--- a/src/XlsCellSet.h
+++ b/src/XlsCellSet.h
@@ -35,8 +35,9 @@ public:
     : nominal_(limits)
   {
     if (sheet_i >= wb.n_sheets()) {
-      cpp11::stop("Can't retrieve sheet in position %d, only %d sheet(s) found.",
-                  sheet_i + 1, wb.n_sheets());
+      readxl_stop("Can't retrieve sheet in position " +
+                  std::to_string(sheet_i + 1) + ", only " +
+                  std::to_string(wb.n_sheets()) + " sheet(s) found.");
     }
     sheetName_ = wb.sheets()[sheet_i];
 
@@ -55,8 +56,8 @@ public:
 
     pWS_ = xls::xls_getWorkSheet(pWB_, sheet_i);
     if (!pWS_) {
-      cpp11::stop("Sheet '%s' (position %d): cannot be opened",
-                  sheetName_.c_str(), sheet_i + 1);
+      readxl_stop("Sheet '" + sheetName_ + "' (position " +
+                  std::to_string(sheet_i + 1) + "): cannot be opened");
     }
     error = xls::xls_parseWorkSheet(pWS_);
     if (error != xls::LIBXLS_OK) {

--- a/src/XlsxCell.h
+++ b/src/XlsxCell.h
@@ -177,8 +177,8 @@ public:
       return;
     }
 
-    cpp11::warning("Unrecognized cell type at %s: '%s'",
-                  cellPosition(row(), col()).c_str(), t->value());
+    readxl_warning("Unrecognized cell type at " + cellPosition(row(), col()) +
+                   ": '" + std::string(t->value()) + "'");
   }
 
   std::string asStdString(const bool trimWs,
@@ -231,7 +231,7 @@ public:
     }
 
     default:
-      cpp11::warning("Unrecognized cell type at %s", cellPosition(row(), col()).c_str());
+      readxl_warning("Unrecognized cell type at " + cellPosition(row(), col()));
       return "";
   }
   }
@@ -260,7 +260,7 @@ public:
     }
 
     default:
-      cpp11::warning("Unrecognized cell type at %s", cellPosition(row(), col()).c_str());
+      readxl_warning("Unrecognized cell type at " + cellPosition(row(), col()));
       return NA_LOGICAL;
     }
   }
@@ -282,7 +282,7 @@ public:
     }
 
     default:
-      cpp11::warning("Unrecognized cell type at %s", cellPosition(row(), col()).c_str());
+      readxl_warning("Unrecognized cell type at " + cellPosition(row(), col()));
       return NA_REAL;
     }
   }
@@ -304,7 +304,7 @@ public:
     }
 
     default:
-      cpp11::warning("Unrecognized cell type at %s", cellPosition(row(), col()).c_str());
+      readxl_warning("Unrecognized cell type at " + cellPosition(row(), col()));
       return NA_REAL;
     }
   }
@@ -315,7 +315,8 @@ private:
                               const std::vector<std::string>& stringTable) const {
     int id = atoi(val);
     if (id < 0 || id >= (int) stringTable.size()) {
-      cpp11::warning("Invalid string id at %s: %i", cellPosition(row(), col()).c_str(), id);
+      readxl_warning("Invalid string id at " + cellPosition(row(), col()) +
+                     ": " + std::to_string(id));
       return "";
     }
     const std::string& string = stringTable.at(id);

--- a/src/XlsxCellSet.h
+++ b/src/XlsxCellSet.h
@@ -50,8 +50,9 @@ public:
     :  nominal_(limits)
   {
     if (sheet_i >= wb.n_sheets()) {
-      cpp11::stop("Can't retrieve sheet in position %d, only %d sheet(s) found.",
-                  sheet_i + 1,  wb.n_sheets());
+      readxl_stop("Can't retrieve sheet in position " +
+                  std::to_string(sheet_i + 1) + ", only " +
+                  std::to_string(wb.n_sheets()) + " sheet(s) found.");
     }
     sheetName_ = wb.sheets()[sheet_i];
     std::string sheetPath = wb.sheetPath(sheet_i);
@@ -64,14 +65,16 @@ public:
     rapidxml::xml_node<>* rootNode;
     rootNode = sheetXml_.first_node("worksheet");
     if (!rootNode) {
-      cpp11::stop("Sheet '%s' (position %d): Invalid sheet xml (no <worksheet>)",
-                  sheetName_.c_str(), sheet_i + 1);
+      readxl_stop("Sheet '" + sheetName_ + "' (position " +
+                  std::to_string(sheet_i + 1) +
+                  "): Invalid sheet xml (no <worksheet>)");
     }
 
     sheetData_ = rootNode->first_node("sheetData");
     if (!sheetData_) {
-      cpp11::stop("Sheet '%s' (position %d): Invalid sheet xml (no <sheetData>)",
-                  sheetName_.c_str(), sheet_i + 1);
+      readxl_stop("Sheet '" + sheetName_ + "' (position " +
+                  std::to_string(sheet_i + 1) +
+                  "): Invalid sheet xml (no <sheetData>)");
     }
 
     // shim = TRUE when user specifies geometry via `range`

--- a/src/XlsxWorkBook.h
+++ b/src/XlsxWorkBook.h
@@ -34,7 +34,7 @@ class XlsxWorkBook {
 
       rapidxml::xml_node<>* relationships = rels_xml.first_node("Relationships");
       if (relationships == NULL) {
-        cpp11::stop("Spreadsheet has no package-level relationships");
+        readxl_stop("Spreadsheet has no package-level relationships");
       }
 
       std::map<std::string, std::string> scratch;
@@ -56,7 +56,7 @@ class XlsxWorkBook {
       // ECMA-376 Part 1 section 8.5 SpreadsheetML
       std::map<std::string, std::string>::iterator m = scratch.find("officeDocument");
       if (m == scratch.end()) {
-        cpp11::stop("No workbook part found");
+        readxl_stop("No workbook part found");
       }
       // store 'xl/workbook.xml', not '/xl/workbook.xml' (rare, but have seen)
       part_["officeDocument"] = removeLeadingSlashes(m->second);
@@ -174,7 +174,7 @@ class XlsxWorkBook {
       std::string id = cpp11::r_string(id_[sheet_i]);
       std::map<std::string, std::string>::const_iterator it = target_.find(id);
       if (it == target_.end()) {
-        cpp11::stop("`%s` not found", id.c_str());
+        readxl_stop("`" + id + "` not found");
       }
       return it->second;
     }

--- a/src/utils.h
+++ b/src/utils.h
@@ -6,6 +6,7 @@
 #include <cmath>
 #include <cstring>
 #include <sstream>
+#include <string>
 
 //May appear in cpp11
 template <typename T, typename N>
@@ -13,6 +14,37 @@ T new_vector(R_xlen_t size, N val) {
   T out(size);
   std::fill(out.begin(), out.end(), val);
   return out;
+}
+
+// Pre-formatted warning/error helpers that avoid cpp11's variadic-template
+// forwarding for warning()/stop(). With clang 21 + R 4.6 on Apple Silicon
+// (and Linux clang on CRAN), `cpp11::warning(fmt, args...)` segfaults inside
+// its closure/tuple forwarding to Rf_warningcall. Wrapping a direct call to
+// Rf_warningcall / Rf_errorcall in cpp11::unwind_protect keeps longjmp
+// protection without going through the broken path.
+inline void readxl_warning(const char* msg) {
+  cpp11::unwind_protect([&] {
+    Rf_warningcall(R_NilValue, "%s", msg);
+  });
+}
+
+inline void readxl_warning(const std::string& msg) {
+  readxl_warning(msg.c_str());
+}
+
+[[noreturn]] inline void readxl_stop(const char* msg) {
+  cpp11::unwind_protect([&] {
+    Rf_errorcall(R_NilValue, "%s", msg);
+  });
+  // Unreachable: Rf_errorcall longjmps and cpp11::unwind_protect rethrows it
+  // as a unwind_exception. The compiler can't see through that, so hint it
+  // explicitly to satisfy [[noreturn]] without leaving a real terminator
+  // (R CMD check flags `abort` / `exit` in compiled code).
+  __builtin_unreachable();
+}
+
+[[noreturn]] inline void readxl_stop(const std::string& msg) {
+  readxl_stop(msg.c_str());
 }
 
 // The date offset needed to align Excel dates with R's use of 1970-01-01
@@ -97,7 +129,8 @@ inline std::pair<int, int> parseRef(const char* ref) {
     } else if (*cur >= 'A' && *cur <= 'Z') {
       col = 26 * col + (*cur - 'A' + 1);
     } else {
-      cpp11::stop("Invalid character '%s' in cell ref '%s'", *cur, ref);
+      readxl_stop(std::string("Invalid character '") + *cur +
+                  "' in cell ref '" + ref + "'");
     }
   }
 

--- a/src/utils.h
+++ b/src/utils.h
@@ -6,6 +6,7 @@
 #include <cmath>
 #include <cstring>
 #include <sstream>
+#include <stdexcept>
 #include <string>
 
 //May appear in cpp11
@@ -17,11 +18,10 @@ T new_vector(R_xlen_t size, N val) {
 }
 
 // Pre-formatted warning/error helpers that avoid cpp11's variadic-template
-// forwarding for warning()/stop(). With clang 21 + R 4.6 on Apple Silicon
-// (and Linux clang on CRAN), `cpp11::warning(fmt, args...)` segfaults inside
-// its closure/tuple forwarding to Rf_warningcall. Wrapping a direct call to
-// Rf_warningcall / Rf_errorcall in cpp11::unwind_protect keeps longjmp
-// protection without going through the broken path.
+// forwarding for warning()/stop(). With clang and cpp11 0.5.4, we've seen
+// segfaults from `cpp11::warning(fmt, args...)`.
+// https://github.com/tidyverse/readxl/issues/784
+// https://github.com/r-lib/cpp11/issues/491
 inline void readxl_warning(const char* msg) {
   cpp11::unwind_protect([&] {
     Rf_warningcall(R_NilValue, "%s", msg);
@@ -36,11 +36,12 @@ inline void readxl_warning(const std::string& msg) {
   cpp11::unwind_protect([&] {
     Rf_errorcall(R_NilValue, "%s", msg);
   });
-  // Unreachable: Rf_errorcall longjmps and cpp11::unwind_protect rethrows it
-  // as a unwind_exception. The compiler can't see through that, so hint it
-  // explicitly to satisfy [[noreturn]] without leaving a real terminator
-  // (R CMD check flags `abort` / `exit` in compiled code).
-  __builtin_unreachable();
+  // Approach taken from cpp11.
+  // Compiler hint to allow [[noreturn]] attribute; this is never executed since
+  // the above call will not return.
+  // Avoids trouble with R CMD check.
+
+  throw std::runtime_error("[[noreturn]]");
 }
 
 [[noreturn]] inline void readxl_stop(const std::string& msg) {


### PR DESCRIPTION
Closes #784

readxl segfaults in various places:

- r-universe (segfault; reported in #784)
- CRAN: `r-devel-linux-x86_64-{debian,fedora}-clang` (segfault); `r-release-macos-x86_64` (segfault);
 https://cran.r-project.org/web/checks/check_results_readxl.html.
- Local: macOS arm64, Apple clang 21, with the "right" compilation flags.

Whether you see a segfault or some other failure mode (e.g. indefinitie hang) appear to depend on compilation flags. Some of these other presentations are seen:

- CRAN's additional checks on `M1Mac` ("Warning: elapsed-time limit of 1.5 hours reached for sub-process")
- readxl's own CI on macos-latest, e.g. https://github.com/tidyverse/readxl/actions/runs/25193092291/job/73867448241. I've had to just kill those jobs.
- Locally, with default compilation flags.

From bisection, it appears to be a regression triggered by upgrading cpp11 from 0.5.3 to 0.5.4 (released 2026-04-09 on CRAN).

Claude Code analysis: lldb shows the crash deep inside cpp11's `safe[Rf_warningcall]` machinery — specifically `std::tuple_leaf::get(this=0x0000ffff01000000)` while `apply()` is unpacking the tuple of forwarded references that the closure passed to `R_UnwindProtect` was built from. The leaf address is corrupted (the 0xffff... pattern looks PAC-failure-like, but the same crash hits Linux clang 21 with no PAC, so likely a generic codegen/lifetime issue rather than PAC).

Workaround taken in this PR: format warning and stop messages into a `std::string` ourselves and call `Rf_warningcall` / `Rf_errorcall` directly inside `cpp11::unwind_protect`. This keeps longjmp protection but avoids cpp11's variadic-template arg forwarding entirely.

Filed upstream at https://github.com/r-lib/cpp11/issues/491
