### PR TITLE
Remove warning and stop helpers that preformat the message

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -40,10 +40,10 @@ Suggests:
     rmarkdown,
     testthat (>= 3.1.6),
     withr
-LinkingTo: 
-    cpp11 (>= 0.4.0),
+LinkingTo:
+    cpp11 (>= 0.5.4.9000),
     progress
-VignetteBuilder: 
+VignetteBuilder:
     knitr
 Config/Needs/website: tidyverse/tidytemplate, tidyverse
 Config/testthat/edition: 3
@@ -52,3 +52,5 @@ Note: libxls v1.6.3 c199d13
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.3.2
 Config/build/compilation-database: true
+Remotes:
+    r-lib/cpp11

--- a/src/ColSpec.h
+++ b/src/ColSpec.h
@@ -95,8 +95,7 @@ inline std::vector<ColType> colTypeStrings(cpp11::strings x) {
     } else if (type == "skip") {
       types.push_back(COL_SKIP);
     } else {
-      readxl_stop("Unknown column type '" + type + "' at position " +
-                  std::to_string(i + 1));
+      cpp11::stop("Unknown column type '%s' at position %i", type.c_str(), (i + 1));
     }
   }
 
@@ -231,11 +230,8 @@ inline cpp11::strings reconcileNames(cpp11::strings names,
     }
   }
   if (ncol_names != ncol_noskip) {
-    readxl_stop("Sheet " + std::to_string(sheet_i + 1) +
-                " has " + std::to_string(ncol_types) +
-                " columns (" + std::to_string(ncol_noskip) +
-                " unskipped), but `col_names` has length " +
-                std::to_string(ncol_names) + ".");
+    cpp11::stop("Sheet %d has %d columns (%d unskipped), but `col_names` has length %d.",
+               (sheet_i + 1), ncol_types, ncol_noskip, ncol_names);
   }
 
   cpp11::writable::strings newNames(ncol_types);

--- a/src/Read.cpp
+++ b/src/Read.cpp
@@ -42,20 +42,18 @@ cpp11::list read_this_(
     colNames = has_col_names ? ws.colNames(na, trim_ws) : cpp11::writable::strings(ws.ncol());
     break;
   default:
-    readxl_stop("`col_names` must be a logical or character vector");
+    cpp11::stop("`col_names` must be a logical or character vector");
   }
 
   // Get column types --------------------------------------------------
   if (TYPEOF(col_types) != STRSXP) {
-    readxl_stop("`col_types` must be a character vector");
+    cpp11::stop("`col_types` must be a character vector");
   }
   std::vector<ColType> colTypes = colTypeStrings(col_types);
   colTypes = recycleTypes(colTypes, ws.ncol());
   if ((int) colTypes.size() != ws.ncol()) {
-    readxl_stop("Sheet " + std::to_string(sheet_i + 1) + " has " +
-                std::to_string(ws.ncol()) +
-                " columns, but `col_types` has length " +
-                std::to_string(colTypes.size()) + ".");
+    cpp11::stop("Sheet %d has %d columns, but `col_types` has length %d.",
+                sheet_i + 1, ws.ncol(), colTypes.size());
   }
   if (requiresGuess(colTypes)) {
     colTypes = ws.colTypes(colTypes, na, trim_ws, guess_max, has_col_names);

--- a/src/SheetView.h
+++ b/src/SheetView.h
@@ -174,7 +174,8 @@ public:
       case COL_LOGICAL:
         if (type == CELL_DATE) {
           // print date string here, when/if it's possible to do so
-          readxl_warning("Expecting logical in " + cellPosition(i, j) + ": got a date");
+          cpp11::warning("Expecting logical in %s: got a date",
+                         cellPosition(i, j).c_str());
         }
 
         switch(type) {
@@ -191,7 +192,8 @@ public:
           if (logicalFromString(text_string, &text_boolean)) {
             LOGICAL(column)[row] = text_boolean;
           } else {
-            readxl_warning("Expecting logical in " + cellPosition(i, j) + ": got '" + text_string + "'");
+            cpp11::warning("Expecting logical in %s: got '%s'",
+                           cellPosition(i, j).c_str(), text_string.c_str());
             LOGICAL(column)[row] = NA_LOGICAL;
           }
         }
@@ -201,25 +203,26 @@ public:
 
       case COL_DATE:
         if (type == CELL_LOGICAL) {
-          readxl_warning("Expecting date in " + cellPosition(i, j) + ": got boolean");
+          cpp11::warning("Expecting date in %s: got boolean", cellPosition(i, j).c_str());
         }
         if (type == CELL_NUMERIC) {
-          readxl_warning("Coercing numeric to date in " + cellPosition(i, j));
+          cpp11::warning("Coercing numeric to date in %s",
+                         cellPosition(i, j).c_str());
         }
         if (type == CELL_TEXT) {
-          readxl_warning("Expecting date in " + cellPosition(i, j) + ": got '" +
-                         xcell->asStdString(trimWs, wb_.stringTable()) + "'");
+          cpp11::warning("Expecting date in %s: got '%s'", cellPosition(i, j).c_str(),
+                         (xcell->asStdString(trimWs, wb_.stringTable())).c_str());
         }
         REAL(column)[row] = xcell->asDate(wb_.is1904());
         break;
 
       case COL_NUMERIC:
         if (type == CELL_LOGICAL) {
-          readxl_warning("Coercing boolean to numeric in " + cellPosition(i, j));
+          cpp11::warning("Coercing boolean to numeric in %s", cellPosition(i, j).c_str());
         }
         if (type == CELL_DATE) {
           // print date string here, when/if possible
-          readxl_warning("Expecting numeric in " + cellPosition(i, j) + ": got a date");
+          cpp11::warning("Expecting numeric in %s: got a date", cellPosition(i, j).c_str());
         }
         switch(type) {
         case CELL_UNKNOWN:
@@ -234,10 +237,12 @@ public:
           double num_num;
           bool success = doubleFromString(num_string, num_num);
           if (success) {
-            readxl_warning("Coercing text to numeric in " + cellPosition(i, j) + ": '" + num_string + "'");
+            cpp11::warning("Coercing text to numeric in %s: '%s'",
+                           cellPosition(i, j).c_str(), num_string.c_str());
             REAL(column)[row] = num_num;
           } else {
-            readxl_warning("Expecting numeric in " + cellPosition(i, j) + ": got '" + num_string + "'");
+            cpp11::warning("Expecting numeric in %s: got '%s'",
+                           cellPosition(i, j).c_str(), num_string.c_str());
             REAL(column)[row] = NA_REAL;
           }
         }

--- a/src/XlsCell.h
+++ b/src/XlsCell.h
@@ -218,8 +218,8 @@ public:
       break;
 
     default:
-      readxl_warning("Unrecognized cell type at " + cellPosition(row(), col()) +
-                     ": '" + std::to_string(cell_->id) + "'");
+      cpp11::warning("Unrecognized cell type at %s: '%s'",
+                    cellPosition(row(), col()).c_str(), cell_->id);
     ct = CELL_UNKNOWN;
     }
 
@@ -264,8 +264,8 @@ public:
     }
 
     default:
-      readxl_warning("Unrecognized cell type at " + cellPosition(row(), col()) +
-                     ": '" + std::to_string(cell_->id) + "'");
+      cpp11::warning("Unrecognized cell type at %s: '%s'",
+                    cellPosition(row(), col()).c_str(), cell_->id);
       return "";
     }
   }
@@ -291,8 +291,8 @@ public:
       return cell_->d != 0;
 
     default:
-      readxl_warning("Unrecognized cell type at " + cellPosition(row(), col()) +
-                     ": '" + std::to_string(cell_->id) + "'");
+      cpp11::warning("Unrecognized cell type at %s: '%s'",
+                    cellPosition(row(), col()).c_str(), cell_->id);
     return NA_LOGICAL;
     }
   }
@@ -311,8 +311,8 @@ public:
       return cell_->d;
 
     default:
-      readxl_warning("Unrecognized cell type at " + cellPosition(row(), col()) +
-                     ": '" + std::to_string(cell_->id) + "'");
+      cpp11::warning("Unrecognized cell type at %s: '%s'",
+                    cellPosition(row(), col()).c_str(), cell_->id);
     return NA_REAL;
     }
   }
@@ -331,8 +331,8 @@ public:
       return POSIXctFromSerial(cell_->d, is1904);
 
     default:
-      readxl_warning("Unrecognized cell type at " + cellPosition(row(), col()) +
-                     ": '" + std::to_string(cell_->id) + "'");
+      cpp11::warning("Unrecognized cell type at %s: '%s'",
+                    cellPosition(row(), col()).c_str(), cell_->id);
     return NA_REAL;
     }
   }

--- a/src/XlsCellSet.h
+++ b/src/XlsCellSet.h
@@ -35,9 +35,8 @@ public:
     : nominal_(limits)
   {
     if (sheet_i >= wb.n_sheets()) {
-      readxl_stop("Can't retrieve sheet in position " +
-                  std::to_string(sheet_i + 1) + ", only " +
-                  std::to_string(wb.n_sheets()) + " sheet(s) found.");
+      cpp11::stop("Can't retrieve sheet in position %d, only %d sheet(s) found.",
+                  sheet_i + 1, wb.n_sheets());
     }
     sheetName_ = wb.sheets()[sheet_i];
 
@@ -56,8 +55,8 @@ public:
 
     pWS_ = xls::xls_getWorkSheet(pWB_, sheet_i);
     if (!pWS_) {
-      readxl_stop("Sheet '" + sheetName_ + "' (position " +
-                  std::to_string(sheet_i + 1) + "): cannot be opened");
+      cpp11::stop("Sheet '%s' (position %d): cannot be opened",
+                  sheetName_.c_str(), sheet_i + 1);
     }
     error = xls::xls_parseWorkSheet(pWS_);
     if (error != xls::LIBXLS_OK) {

--- a/src/XlsCellSet.h
+++ b/src/XlsCellSet.h
@@ -44,8 +44,7 @@ public:
     spinner_.spin();
     pWB_ = xls_open_file(wb.path().c_str(), "UTF-8", &error);
     if (!pWB_) {
-      Rf_errorcall(
-        R_NilValue,
+      cpp11::stop(
         "\n  filepath: %s\n  libxls error: %s",
         wb.path().c_str(),
         xls::xls_getError(error)
@@ -60,8 +59,7 @@ public:
     }
     error = xls::xls_parseWorkSheet(pWS_);
     if (error != xls::LIBXLS_OK) {
-      Rf_errorcall(
-        R_NilValue,
+      cpp11::stop(
         "\n  filepath: %s\n  sheet: %s\n  libxls error: %s",
         wb.path().c_str(),
         sheetName_.c_str(),

--- a/src/XlsWorkBook.h
+++ b/src/XlsWorkBook.h
@@ -36,8 +36,7 @@ public:
     xls::xls_error_t error = xls::LIBXLS_OK;
     xls::xlsWorkBook* pWB_ = xls::xls_open_file(path_.c_str(), "UTF-8", &error);
     if (!pWB_) {
-      Rf_errorcall(
-        R_NilValue,
+      cpp11::stop(
         "\n  filepath: %s\n  libxls error: %s",
         path_.c_str(),
         xls::xls_getError(error)

--- a/src/XlsxCell.h
+++ b/src/XlsxCell.h
@@ -177,8 +177,8 @@ public:
       return;
     }
 
-    readxl_warning("Unrecognized cell type at " + cellPosition(row(), col()) +
-                   ": '" + std::string(t->value()) + "'");
+    cpp11::warning("Unrecognized cell type at %s: '%s'",
+                  cellPosition(row(), col()).c_str(), t->value());
   }
 
   std::string asStdString(const bool trimWs,
@@ -231,7 +231,7 @@ public:
     }
 
     default:
-      readxl_warning("Unrecognized cell type at " + cellPosition(row(), col()));
+      cpp11::warning("Unrecognized cell type at %s", cellPosition(row(), col()).c_str());
       return "";
   }
   }
@@ -260,7 +260,7 @@ public:
     }
 
     default:
-      readxl_warning("Unrecognized cell type at " + cellPosition(row(), col()));
+      cpp11::warning("Unrecognized cell type at %s", cellPosition(row(), col()).c_str());
       return NA_LOGICAL;
     }
   }
@@ -282,7 +282,7 @@ public:
     }
 
     default:
-      readxl_warning("Unrecognized cell type at " + cellPosition(row(), col()));
+      cpp11::warning("Unrecognized cell type at %s", cellPosition(row(), col()).c_str());
       return NA_REAL;
     }
   }
@@ -304,7 +304,7 @@ public:
     }
 
     default:
-      readxl_warning("Unrecognized cell type at " + cellPosition(row(), col()));
+      cpp11::warning("Unrecognized cell type at %s", cellPosition(row(), col()).c_str());
       return NA_REAL;
     }
   }
@@ -315,8 +315,7 @@ private:
                               const std::vector<std::string>& stringTable) const {
     int id = atoi(val);
     if (id < 0 || id >= (int) stringTable.size()) {
-      readxl_warning("Invalid string id at " + cellPosition(row(), col()) +
-                     ": " + std::to_string(id));
+      cpp11::warning("Invalid string id at %s: %i", cellPosition(row(), col()).c_str(), id);
       return "";
     }
     const std::string& string = stringTable.at(id);

--- a/src/XlsxCellSet.h
+++ b/src/XlsxCellSet.h
@@ -50,9 +50,8 @@ public:
     :  nominal_(limits)
   {
     if (sheet_i >= wb.n_sheets()) {
-      readxl_stop("Can't retrieve sheet in position " +
-                  std::to_string(sheet_i + 1) + ", only " +
-                  std::to_string(wb.n_sheets()) + " sheet(s) found.");
+      cpp11::stop("Can't retrieve sheet in position %d, only %d sheet(s) found.",
+                  sheet_i + 1,  wb.n_sheets());
     }
     sheetName_ = wb.sheets()[sheet_i];
     std::string sheetPath = wb.sheetPath(sheet_i);
@@ -65,16 +64,14 @@ public:
     rapidxml::xml_node<>* rootNode;
     rootNode = sheetXml_.first_node("worksheet");
     if (!rootNode) {
-      readxl_stop("Sheet '" + sheetName_ + "' (position " +
-                  std::to_string(sheet_i + 1) +
-                  "): Invalid sheet xml (no <worksheet>)");
+      cpp11::stop("Sheet '%s' (position %d): Invalid sheet xml (no <worksheet>)",
+                  sheetName_.c_str(), sheet_i + 1);
     }
 
     sheetData_ = rootNode->first_node("sheetData");
     if (!sheetData_) {
-      readxl_stop("Sheet '" + sheetName_ + "' (position " +
-                  std::to_string(sheet_i + 1) +
-                  "): Invalid sheet xml (no <sheetData>)");
+      cpp11::stop("Sheet '%s' (position %d): Invalid sheet xml (no <sheetData>)",
+                  sheetName_.c_str(), sheet_i + 1);
     }
 
     // shim = TRUE when user specifies geometry via `range`

--- a/src/XlsxWorkBook.h
+++ b/src/XlsxWorkBook.h
@@ -34,7 +34,7 @@ class XlsxWorkBook {
 
       rapidxml::xml_node<>* relationships = rels_xml.first_node("Relationships");
       if (relationships == NULL) {
-        readxl_stop("Spreadsheet has no package-level relationships");
+        cpp11::stop("Spreadsheet has no package-level relationships");
       }
 
       std::map<std::string, std::string> scratch;
@@ -56,7 +56,7 @@ class XlsxWorkBook {
       // ECMA-376 Part 1 section 8.5 SpreadsheetML
       std::map<std::string, std::string>::iterator m = scratch.find("officeDocument");
       if (m == scratch.end()) {
-        readxl_stop("No workbook part found");
+        cpp11::stop("No workbook part found");
       }
       // store 'xl/workbook.xml', not '/xl/workbook.xml' (rare, but have seen)
       part_["officeDocument"] = removeLeadingSlashes(m->second);
@@ -174,7 +174,7 @@ class XlsxWorkBook {
       std::string id = cpp11::r_string(id_[sheet_i]);
       std::map<std::string, std::string>::const_iterator it = target_.find(id);
       if (it == target_.end()) {
-        readxl_stop("`" + id + "` not found");
+        cpp11::stop("`%s` not found", id.c_str());
       }
       return it->second;
     }

--- a/src/utils.h
+++ b/src/utils.h
@@ -6,8 +6,6 @@
 #include <cmath>
 #include <cstring>
 #include <sstream>
-#include <stdexcept>
-#include <string>
 
 //May appear in cpp11
 template <typename T, typename N>
@@ -15,37 +13,6 @@ T new_vector(R_xlen_t size, N val) {
   T out(size);
   std::fill(out.begin(), out.end(), val);
   return out;
-}
-
-// Pre-formatted warning/error helpers that avoid cpp11's variadic-template
-// forwarding for warning()/stop(). With clang and cpp11 0.5.4, we've seen
-// segfaults from `cpp11::warning(fmt, args...)`.
-// https://github.com/tidyverse/readxl/issues/784
-// https://github.com/r-lib/cpp11/issues/491
-inline void readxl_warning(const char* msg) {
-  cpp11::unwind_protect([&] {
-    Rf_warningcall(R_NilValue, "%s", msg);
-  });
-}
-
-inline void readxl_warning(const std::string& msg) {
-  readxl_warning(msg.c_str());
-}
-
-[[noreturn]] inline void readxl_stop(const char* msg) {
-  cpp11::unwind_protect([&] {
-    Rf_errorcall(R_NilValue, "%s", msg);
-  });
-  // Approach taken from cpp11.
-  // Compiler hint to allow [[noreturn]] attribute; this is never executed since
-  // the above call will not return.
-  // Avoids trouble with R CMD check.
-
-  throw std::runtime_error("[[noreturn]]");
-}
-
-[[noreturn]] inline void readxl_stop(const std::string& msg) {
-  readxl_stop(msg.c_str());
 }
 
 // The date offset needed to align Excel dates with R's use of 1970-01-01
@@ -130,8 +97,7 @@ inline std::pair<int, int> parseRef(const char* ref) {
     } else if (*cur >= 'A' && *cur <= 'Z') {
       col = 26 * col + (*cur - 'A' + 1);
     } else {
-      readxl_stop(std::string("Invalid character '") + *cur +
-                  "' in cell ref '" + ref + "'");
+      cpp11::stop("Invalid character '%s' in cell ref '%s'", *cur, ref);
     }
   }
 

--- a/src/utils.h
+++ b/src/utils.h
@@ -75,12 +75,12 @@ inline double POSIXctFromSerial(double xlDate, bool is1904) {
     if (xlDate < 60) {
       xlDate = xlDate + 1;
     } else {
-      Rf_warning("NA inserted for impossible 1900-02-29 datetime");
+      cpp11::warning("NA inserted for impossible 1900-02-29 datetime");
       return NA_REAL;
     }
   }
   if (xlDate < 0) {
-    Rf_warning("NA inserted for an unsupported date prior to 1900");
+    cpp11::warning("NA inserted for an unsupported date prior to 1900");
     return NA_REAL;
   } else {
     return dateRound((xlDate - dateOffset(is1904)) * 86400);

--- a/tests/testthat/_snaps/dates.md
+++ b/tests/testthat/_snaps/dates.md
@@ -4,7 +4,7 @@
       df <- read_excel(test_sheet("dates-leap-year-1900-xlsx.xlsx"), col_types = c(
         "date", "text", "logical"))
     Condition
-      Warning in `read_fun()`:
+      Warning:
       NA inserted for impossible 1900-02-29 datetime
 
 # we get correct dates prior to March 1, 1900, in 1900 date system [xls]
@@ -13,6 +13,6 @@
       df <- read_excel(test_sheet("dates-leap-year-1900-xls.xls"), col_types = c(
         "date", "text", "logical"))
     Condition
-      Warning in `read_fun()`:
+      Warning:
       NA inserted for impossible 1900-02-29 datetime
 


### PR DESCRIPTION
Test driving the cpp11 fix

https://github.com/r-lib/cpp11/pull/493

Also going back even further in time and finding places where readxl called `Rf_errorcall()` and `Rf_warning()` directly, presumably because it skirted this not-yet-understood problem.