### PR TITLE
Adopt a different convention re order of includes

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # readxl (development version)
 
+* readxl should once again compile on Alpine Linux. (#775)
+
 # readxl 1.4.5
 
 This release contains no user-facing changes.

--- a/maintenance/02_apply-our-libxls-patches.txt
+++ b/maintenance/02_apply-our-libxls-patches.txt
@@ -48,3 +48,12 @@
 # git diff ':!maintenance/02_apply-our-libxls-patches.txt' > maintenance/patches/snprintf.patch
 # discard changes
 # git apply maintenance/patches/snprintf.patch
+
+# Implement the include of <stdint.h> in the global namespace at the top of
+# src/libxls/xls.h, before the `namespace xls { extern "C" {` block opens, so
+# that stdint typedefs (int64_t etc.) aren't trapped in xls:: when libxls is
+# consumed from C++ on a libc (e.g. musl/Alpine) that hasn't transitively
+# pre-loaded <stdint.h>. (#775)
+# git diff ':!maintenance/02_apply-our-libxls-patches.txt' > maintenance/patches/stdint.patch
+# discard changes
+# git apply maintenance/patches/stdint.patch

--- a/maintenance/patches/stdint.patch
+++ b/maintenance/patches/stdint.patch
@@ -1,0 +1,20 @@
+diff --git a/src/libxls/xls.h b/src/libxls/xls.h
+index 89b8b92..59da631 100644
+--- a/src/libxls/xls.h
++++ b/src/libxls/xls.h
+@@ -33,7 +33,14 @@
+ 
+ #ifndef XLS_INCLUDE
+ #define XLS_INCLUDE
+- 
++
++/* readxl modification: process <stdint.h> in the global namespace, not inside
++ * namespace xls. Otherwise, on libcs (e.g. musl/Alpine) where <stdint.h> has
++ * not been transitively pre-loaded by other system or vendored headers, its
++ * typedefs (int64_t etc.) end up trapped in xls:: when libxls is consumed
++ * from C++ code. See readxl issue #775. */
++#include <stdint.h>
++
+ #ifdef __cplusplus
+ namespace xls {
+ extern "C" {

--- a/src/CellLimits.h
+++ b/src/CellLimits.h
@@ -1,8 +1,10 @@
 #pragma once
 
-#include "XlsCell.h"
-#include "cpp11/integers.hpp"
 #include <vector>
+
+#include "cpp11/integers.hpp"
+
+#include "XlsCell.h"
 
 class CellLimits {
   int minRow_, maxRow_, minCol_, maxCol_;

--- a/src/ColSpec.h
+++ b/src/ColSpec.h
@@ -1,16 +1,16 @@
 #pragma once
 
-#include "utils.h"
-#include "StringSet.h"
-
-#include "libxls/xls.h"
-
 #include "cpp11/doubles.hpp"
 #include "cpp11/list.hpp"
 #include "cpp11/logicals.hpp"
 #include "cpp11/protect.hpp"
 #include "cpp11/sexp.hpp"
 #include "cpp11/strings.hpp"
+
+#include "libxls/xls.h"
+
+#include "StringSet.h"
+#include "utils.h"
 
 enum CellType {
   CELL_UNKNOWN,

--- a/src/Read.cpp
+++ b/src/Read.cpp
@@ -1,13 +1,12 @@
-#include "SheetView.h"
-
-#include "ColSpec.h"
+#include <string>
 
 #include "cpp11/as.hpp"
 #include "cpp11/list.hpp"
 #include "cpp11/R.hpp"
 #include "cpp11/strings.hpp"
 
-#include <string>
+#include "ColSpec.h"
+#include "SheetView.h"
 
 template <typename T>
 cpp11::list read_this_(

--- a/src/SheetView.h
+++ b/src/SheetView.h
@@ -1,21 +1,20 @@
-#include <sys/time.h> // alpine linux / musl must be before others
-#include <unistd.h>   // alpine linux / musl must be before others
-
-#include "CellLimits.h"
-#include "ColSpec.h"
-#include "XlsWorkBook.h"
-#include "XlsxWorkBook.h"
-#include "XlsCellSet.h"
-#include "XlsxCellSet.h"
-#include "XlsCell.h"
-#include "XlsxCell.h"
+#include <algorithm>
+#include <string>
+#include <sys/time.h>
+#include <unistd.h>
+#include <vector>
 
 #include "cpp11/R.hpp"
 #include "cpp11/strings.hpp"
 
-#include <algorithm>
-#include <string>
-#include <vector>
+#include "CellLimits.h"
+#include "ColSpec.h"
+#include "XlsCell.h"
+#include "XlsCellSet.h"
+#include "XlsWorkBook.h"
+#include "XlsxCell.h"
+#include "XlsxCellSet.h"
+#include "XlsxWorkBook.h"
 
 class Xls {
 public:

--- a/src/StringSet.h
+++ b/src/StringSet.h
@@ -1,12 +1,12 @@
 #pragma once
 
-#include "utils.h"
-
-#include "cpp11/strings.hpp"
-
 #include <cstring>
 #include <set>
 #include <vector>
+
+#include "cpp11/strings.hpp"
+
+#include "utils.h"
 
 class StringSet
 {

--- a/src/XlsCell.h
+++ b/src/XlsCell.h
@@ -1,14 +1,18 @@
 #pragma once
 
-#include "ColSpec.h"
-#include "utils.h"
+#include <cstdint>
+#include <iomanip>
+#include <limits.h>
+
+#include "cpp11/protect.hpp"
+#include "cpp11/sexp.hpp"
 
 #include "libxls/xls.h"
 #include "libxls/xlsstruct.h"
 #include "libxls/xlstypes.h"
 
-#include <iomanip>
-#include <limits.h>
+#include "ColSpec.h"
+#include "utils.h"
 
 // Key reference for understanding the structure of the xls format is
 // [MS-XLS]: Excel Binary File Format (.xls) Structure

--- a/src/XlsCellSet.h
+++ b/src/XlsCellSet.h
@@ -1,13 +1,5 @@
 #pragma once
 
-#include "CellLimits.h"
-#include "Spinner.h"
-#include "XlsCell.h"
-#include "XlsWorkBook.h"
-
-#include "libxls/xls.h"
-#include "libxls/xlsstruct.h"
-
 #include "cpp11/as.hpp"
 #include "cpp11/integers.hpp"
 #include "cpp11/list.hpp"
@@ -15,6 +7,14 @@
 #include "cpp11/R.hpp"
 #include "cpp11/sexp.hpp"
 #include "cpp11/strings.hpp"
+
+#include "libxls/xls.h"
+#include "libxls/xlsstruct.h"
+
+#include "CellLimits.h"
+#include "Spinner.h"
+#include "XlsCell.h"
+#include "XlsWorkBook.h"
 
 class XlsCellSet {
   // xls specifics

--- a/src/XlsWorkBook.h
+++ b/src/XlsWorkBook.h
@@ -1,13 +1,13 @@
 #pragma once
 
-#include "ColSpec.h"
+#include "cpp11/R.hpp"
+#include "cpp11/r_string.hpp"
+#include "cpp11/strings.hpp"
 
 #include "libxls/xls.h"
 #include "libxls/xlsstruct.h"
 
-#include "cpp11/R.hpp"
-#include "cpp11/r_string.hpp"
-#include "cpp11/strings.hpp"
+#include "ColSpec.h"
 
 class XlsWorkBook {
 

--- a/src/XlsxCell.h
+++ b/src/XlsxCell.h
@@ -1,10 +1,10 @@
 #pragma once
 
+#include "rapidxml/rapidxml.h"
+
 #include "ColSpec.h"
 #include "XlsxString.h"
 #include "utils.h"
-
-#include "rapidxml/rapidxml.h"
 
 // Key reference for understanding the structure of the XML is
 // ECMA-376 (http://www.ecma-international.org/publications/standards/Ecma-376.htm)

--- a/src/XlsxCellSet.h
+++ b/src/XlsxCellSet.h
@@ -1,18 +1,18 @@
 #pragma once
 
-#include "CellLimits.h"
-#include "ColSpec.h"
-#include "Spinner.h"
-#include "XlsxCell.h"
-#include "XlsxWorkBook.h"
-
-#include "rapidxml/rapidxml.h"
-
 #include "cpp11/integers.hpp"
 #include "cpp11/list.hpp"
 #include "cpp11/protect.hpp"
 #include "cpp11/sexp.hpp"
 #include "cpp11/strings.hpp"
+
+#include "rapidxml/rapidxml.h"
+
+#include "CellLimits.h"
+#include "ColSpec.h"
+#include "Spinner.h"
+#include "XlsxCell.h"
+#include "XlsxWorkBook.h"
 
 // Page and section numbers below refer to
 // ECMA-376 (version, date, and download URL given in XlsxCell.h)

--- a/src/XlsxString.h
+++ b/src/XlsxString.h
@@ -1,9 +1,10 @@
 #pragma once
 
-#include "rapidxml/rapidxml.h"
-
+// R_ext/GraphicsEngine.h must be included before R_ext/GraphicsDevice.h
 #include <R_ext/GraphicsEngine.h>
-#include <R_ext/GraphicsDevice.h> // Rf_ucstoutf8 is exported in R_ext/GraphicsDevice.h
+#include <R_ext/GraphicsDevice.h> // Rf_ucstoutf8 is exported here
+
+#include "rapidxml/rapidxml.h"
 
 
 // unescape an ST_Xstring. See 22.9.2.19 [p3786]

--- a/src/XlsxWorkBook.h
+++ b/src/XlsxWorkBook.h
@@ -1,16 +1,16 @@
 #pragma once
 
-#include "ColSpec.h"
-#include "utils.h"
-#include "XlsxString.h"
-#include "zip.h"
-
-#include "rapidxml/rapidxml.h"
+#include <map>
 
 #include "cpp11/protect.hpp"
 #include "cpp11/strings.hpp"
 
-#include <map>
+#include "rapidxml/rapidxml.h"
+
+#include "ColSpec.h"
+#include "utils.h"
+#include "XlsxString.h"
+#include "zip.h"
 
 class XlsxWorkBook {
 

--- a/src/libxls/xls.h
+++ b/src/libxls/xls.h
@@ -33,7 +33,14 @@
 
 #ifndef XLS_INCLUDE
 #define XLS_INCLUDE
- 
+
+/* readxl modification: process <stdint.h> in the global namespace, not inside
+ * namespace xls. Otherwise, on libcs (e.g. musl/Alpine) where <stdint.h> has
+ * not been transitively pre-loaded by other system or vendored headers, its
+ * typedefs (int64_t etc.) end up trapped in xls:: when libxls is consumed
+ * from C++ code. See readxl issue #775. */
+#include <stdint.h>
+
 #ifdef __cplusplus
 namespace xls {
 extern "C" {

--- a/src/utils.h
+++ b/src/utils.h
@@ -1,11 +1,11 @@
 #pragma once
 
-#include "cpp11/protect.hpp"
-
 #include <cerrno>
 #include <cmath>
 #include <cstring>
 #include <sstream>
+
+#include "cpp11/protect.hpp"
 
 //May appear in cpp11
 template <typename T, typename N>

--- a/src/zip.cpp
+++ b/src/zip.cpp
@@ -1,11 +1,11 @@
 #include "zip.h"
 
-#include "rapidxml/rapidxml_print.h"
-
 #include "cpp11/as.hpp"
 #include "cpp11/function.hpp"
 #include "cpp11/raws.hpp"
 #include "cpp11/sexp.hpp"
+
+#include "rapidxml/rapidxml_print.h"
 
 std::string zip_buffer(const std::string& zip_path,
                        const std::string& file_path) {

--- a/src/zip.h
+++ b/src/zip.h
@@ -1,7 +1,8 @@
 #pragma once
 
-#include "rapidxml/rapidxml.h"
 #include <string>
+
+#include "rapidxml/rapidxml.h"
 
 std::string zip_buffer(const std::string& zip_path, const std::string& file_path);
 bool zip_has_file(const std::string& zip_path, const std::string& file_path);


### PR DESCRIPTION
Fixes #775 and, hopefully, heads off future Alpine issues of this nature.

Exactly why I was ordering includes as I was has been lost in the sands of time. But this seems more conventional:

system → cpp11 → other vendored (libxls, rapidxml) → project

Within the group, alphabetical. Blank lines between.

For a .cpp file, the corresponding .h sits at the top.

Why system before libxls? we want standard headers like `<stdint.h>` processed in the global namespace, not inside xls. This is #775. (And pretty similar stories in #562, #676, #714.)

Why cpp11 before libxls? libxls transitively pulls in <Rinternals.h> via cran.h, and cpp11 needs to set R_NO_REMAP/STRICT_R_HEADERS before any R header is processed