### PR TITLE
Don't warn just because user can't read a parent directory

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # readxl (development version)
 
+* `read_excel()` and friends should no longer emit a spurious "Access is denied" warning when reading a file on a network drive and the user doesn't have access to a parent directory (#730).
+
 # readxl 1.4.5
 
 This release contains no user-facing changes.

--- a/R/excel-sheets.R
+++ b/R/excel-sheets.R
@@ -18,7 +18,6 @@
 excel_sheets <- function(path) {
   path <- check_file(path)
   format <- check_format(path)
-  path <- normalizePath(path)
 
   switch(format, xls = xls_sheets(path), xlsx = xlsx_sheets(path))
 }

--- a/R/read_excel.R
+++ b/R/read_excel.R
@@ -244,7 +244,6 @@ read_excel_ <- function(
     sheets_fun <- xlsx_sheets
     read_fun <- read_xlsx_
   }
-  path <- normalizePath(path)
   sheet <- standardise_sheet(sheet, range, sheets_fun(path))
   shim <- !is.null(range)
   limits <- standardise_limits(

--- a/R/utils.R
+++ b/R/utils.R
@@ -6,7 +6,13 @@ check_file <- function(path) {
   if (!file.exists(path)) {
     stop("`path` does not exist: ", sQuote(path), call. = FALSE)
   }
-  path
+  # We already know the file exists, so we can use `mustWork = FALSE`.
+  # Why would we want to do that?
+  # https://github.com/tidyverse/readxl/issues/730
+  # There are reports of a spurious "Access is denied" warning when the
+  # file lives on a Windows network share whose parent directory is not
+  # accessible to the user, even though the file itself is readable.
+  normalizePath(path, mustWork = FALSE)
 }
 
 is_integerish <- function(x) {


### PR DESCRIPTION
Fixes #730 

This is a speculative fix, i.e. I haven't personally reproduced the problem and the solution.

But there are many reports of this behaviour on network drives over the years, in many venues. I've moved the `normalizePath(mustWork = FALSE)` call to be close to and right after the file existence check, to make it more clear why this should be OK. I think we're getting the same `normalizePath()` result we've always been getting, we're just going to suppress this spurious warning (and hopefully *only* a spurious warning).